### PR TITLE
Option to set map height (y) below which pokemons are always aggresive

### DIFF
--- a/common/src/main/java/me/rufia/fightorflight/CobblemonFightOrFlight.java
+++ b/common/src/main/java/me/rufia/fightorflight/CobblemonFightOrFlight.java
@@ -1,7 +1,5 @@
 package me.rufia.fightorflight;
 
-
-import com.cobblemon.mod.common.api.pokemon.feature.SpeciesFeature;
 import com.cobblemon.mod.common.api.types.ElementalType;
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
 import com.cobblemon.mod.common.pokemon.Pokemon;
@@ -30,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class CobblemonFightOrFlight {
@@ -101,12 +98,13 @@ public class CobblemonFightOrFlight {
         Pokemon pokemon = pokemonEntity.getPokemon();
         String speciesName = pokemon.getSpecies().getName().toLowerCase();
         Set<String> pokemonAspects = pokemon.getAspects();
+        double height = pokemonEntity.position().y;
 
         if (SpeciesNeverAggro(speciesName) || SpeciesAlwaysFlee(speciesName)) {
             return -100;
         }
 
-        if (SpeciesAlwaysAggro(speciesName) || AspectsAlwaysAggro(pokemonAspects)) {
+        if (SpeciesAlwaysAggro(speciesName) || AspectsAlwaysAggro(pokemonAspects) || BelowAlwaysAggro(height)) {
             return 100;
         }
 
@@ -185,6 +183,10 @@ public class CobblemonFightOrFlight {
         return finalResult;
     }
 
+    public static boolean BelowAlwaysAggro(double height) {
+        return height < CobblemonFightOrFlight.commonConfig().always_aggro_below;
+    }
+
     public static boolean AspectsAlwaysAggro(Set<String> pokemonAspects) {
         // Retrieve the list of always aggressive features from the config
         String[] alwaysAggroFeatures = CobblemonFightOrFlight.commonConfig().always_aggro_aspects;
@@ -200,7 +202,6 @@ public class CobblemonFightOrFlight {
         }
         return false;
     }
-
 
     public static boolean SpeciesAlwaysAggro(String speciesName) {
         //LogUtils.getLogger().info("Are " + speciesName + " always aggro?");

--- a/common/src/main/java/me/rufia/fightorflight/config/FightOrFlightCommonConfigModel.java
+++ b/common/src/main/java/me/rufia/fightorflight/config/FightOrFlightCommonConfigModel.java
@@ -25,6 +25,8 @@ public class FightOrFlightCommonConfigModel implements ConfigData {
     public boolean dark_light_level_aggro = true;
     @Comment("Are Ghost types more aggressive at or below light level 7 and less aggressive at or above light level 12")
     public boolean ghost_light_level_aggro = true;
+    @Comment("Pokemon below this map height (y) will always be aggressive")
+    public double always_aggro_below = -128;
     @Comment("Forms that will always be aggressive")
     public String[] always_aggro_aspects = {
             "alolan"


### PR DESCRIPTION
Another feature requested on discord.  If pokemon spawns or moves below set height it is aggressive.

Tested and working fine.